### PR TITLE
Analysisgrid improvements

### DIFF
--- a/honeybee/radiance/analysisgrid.py
+++ b/honeybee/radiance/analysisgrid.py
@@ -192,19 +192,19 @@ class AnalysisGrid(object):
                         inf.next()  # pass empty line
                         break  # done with the header!
                     elif startLine == 0 and line[:5] == 'NROWS':
-                        pointsCount = int(inf.next().split('=')[-1])
+                        pointsCount = int(line.split('=')[-1])
                         if checkPointCount:
                             assert len(self._analysisPoints) == pointsCount, \
-                                "Length of points [{}] doesn't match length " \
-                                "of the results [{}].".format(
+                                "Length of points [{}] must match the number " \
+                                "of rows [{}].".format(
                                     len(self._analysisPoints), pointsCount)
 
                     elif startLine == 0 and line[:5] == 'NCOLS':
-                        hoursCount = int(inf.next().split('=')[-1])
+                        hoursCount = int(line.split('=')[-1])
                         if hoys:
                             assert hoursCount == len(hoys), \
-                                "Number of hours [{}] doesn't match length " \
-                                "of the results [{}]." \
+                                "Number of hours [{}] must match the " \
+                                "number of columns [{}]." \
                                 .format(len(hoys), hoursCount)
                         else:
                             hoys = xrange(0, hoursCount)
@@ -256,33 +256,34 @@ class AnalysisGrid(object):
                 # read the header
                 for i in xrange(10):
                     line = inf.next()
+                    dline = dinf.next()
                     dinf.next()
                     if line[:6] == 'FORMAT':
                         inf.next()  # pass empty line
                         dinf.next()
                         break  # done with the header!
                     elif startLine == 0 and line[:5] == 'NROWS':
-                        pointsCount = int(inf.next().split('=')[-1])
-                        dirPointsCount = int(dinf.next().split('=')[-1])
+                        pointsCount = int(line.split('=')[-1])
+                        dirPointsCount = int(dline.split('=')[-1])
                         assert pointsCount == dirPointsCount, \
                             'Number of points in files ' \
                             'must be equal {} != {}'.format(pointsCount,
                                                             dirPointsCount)
                         if checkPointCount:
                             assert len(self._analysisPoints) == pointsCount, \
-                                "Length of points [{}] doesn't match length " \
+                                "Length of points [{}] must match the length " \
                                 "of the results [{}].".format(
                                     len(self._analysisPoints), pointsCount)
 
                     elif startLine == 0 and line[:5] == 'NCOLS':
-                        hoursCount = int(inf.next().split('=')[-1])
-                        dirHoursCount = int(dinf.next().split('=')[-1])
+                        hoursCount = int(line.split('=')[-1])
+                        dirHoursCount = int(dline.split('=')[-1])
                         assert hoursCount == dirHoursCount, \
                             'Number of hours in files ' \
                             'must be equal {} != {}'.format(hoursCount, dirHoursCount)
                         if hoys:
                             assert hoursCount == len(hoys), \
-                                "Number of hours [{}] doesn't match length " \
+                                "Number of hours [{}] must match length " \
                                 "of the results [{}]." \
                                 .format(len(hoys), hoursCount)
                         else:

--- a/honeybee/radiance/analysispoint.py
+++ b/honeybee/radiance/analysispoint.py
@@ -210,7 +210,7 @@ class AnalysisPoint(object):
         """Set value for a specific hour of the year.
 
         Args:
-            value: Illuminance value as a number.
+            value: Value as a number.
             hoy: The hour of the year that corresponds to this value.
             source: Name of the source of light. Only needed in case of multiple
                 sources / window groups (default: None).
@@ -227,7 +227,7 @@ class AnalysisPoint(object):
         """Set values for several hours of the year.
 
         Args:
-            values: List of Illuminance values as numbers.
+            values: List of values as numbers.
             hoys: List of hours of the year that corresponds to input values.
             source: Name of the source of light. Only needed in case of multiple
                 sources / window groups (default: None).
@@ -248,6 +248,7 @@ class AnalysisPoint(object):
             self._isDirectLoaded = True
 
         ind = 1 if isDirect else 0
+
         for hoy, value in izip(hoys, values):
             try:
                 self._values[sid][stateid][hoy][ind] = value
@@ -262,7 +263,7 @@ class AnalysisPoint(object):
         """Set both total and direct values for a specific hour of the year.
 
         Args:
-            value: Illuminance value as as tuples (total, direct).
+            value: Value as as tuples (total, direct).
             hoy: The hour of the year that corresponds to this value.
             source: Name of the source of light. Only needed in case of multiple
                 sources / window groups (default: None).
@@ -287,7 +288,7 @@ class AnalysisPoint(object):
         """Set total and direct values for several hours of the year.
 
         Args:
-            values: List of Illuminance values as tuples (total, direct).
+            values: List of values as tuples (total, direct).
             hoys: List of hours of the year that corresponds to input values.
             source: Name of the source of light. Only needed in case of multiple
                 sources / window groups (default: None).
@@ -750,10 +751,13 @@ class AnalysisPoint(object):
     def duplicate(self):
         """Duplicate the analysis point."""
         ap = AnalysisPoint(self._loc, self._dir)
-        ap._sources = self._sources
         # This should be good enough as most of the time an analysis point will be
         # copied with no values assigned.
         ap._values = copy.copy(self._values)
+
+        if len(ap._values) == len(self._sources):
+            ap._sources = self._sources
+
         ap._isDirectLoaded = bool(self._isDirectLoaded)
         ap.logic = copy.copy(self.logic)
         return ap

--- a/honeybee/radiance/command/rcontrib.py
+++ b/honeybee/radiance/command/rcontrib.py
@@ -36,7 +36,10 @@ class Rcontrib(RadianceCommand):
         rcontrib.rcontribParameters.ad = 10000
 
         print rcontrib.toRadString()
-        > c:/radiance/bin/rcontrib -ab 0 -ad 10000 -M C:/ladybug/test3/gridbased/sunlist.txt -I C:/ladybug/test3/gridbased/test3.oct < C:/ladybug/test3/gridbased/test3.pts > test3.dc
+        > c:/radiance/bin/rcontrib -ab 0 -ad 10000 -M
+            C:/ladybug/test3/gridbased/sunlist.txt -I
+            C:/ladybug/test3/gridbased/test3.oct <
+            C:/ladybug/test3/gridbased/test3.pts > test3.dc
 
         # run rcontrib
         rcontrib.execute()

--- a/honeybee/radiance/parameters/rcontrib.py
+++ b/honeybee/radiance/parameters/rcontrib.py
@@ -45,10 +45,11 @@ class RcontribParameters(GridBasedParameters):
         # or you can set all the parameter for rtrace based on quality
         rcp.quality = 1
         print rcp.toRadString()
-        > -aa 0.2 -ab 0 -ad 10000 -M c:/ladybug/suns.txt -I -dc 0.5 -st 0.5 -lw 0.01 -as 2048 -ar 64 -lr 6 -dt 0.25 -dr 1 -ds 0.25 -dp 256
+        > -aa 0.2 -ab 0 -ad 10000 -M c:/ladybug/suns.txt -I -dc 0.5 -st 0.5 -lw 0.01
+            -as 2048 -ar 64 -lr 6 -dt 0.25 -dr 1 -ds 0.25 -dp 256
     """
 
-    def __init__(self, modFile=None):
+    def __init__(self, modFile=None, totalPointCount=None):
         """Init paramters."""
         GridBasedParameters.__init__(self)
 
@@ -57,3 +58,8 @@ class RcontribParameters(GridBasedParameters):
         self.modFile = modFile
         """[-M file] File path to a file with a list of modifiers
         (Default: None)"""
+
+        self.addRadianceNumber('y', 'number of total points or pixels',
+                               attributeName='totalPointCount')
+        self.totalPointCount = totalPointCount
+        """"[-y int] Number of total points in points file."""

--- a/honeybee/radiance/recipe/daylightcoeff/gridbased.py
+++ b/honeybee/radiance/recipe/daylightcoeff/gridbased.py
@@ -271,7 +271,7 @@ class DaylightCoeffGridBased(GenericGridBased):
             fn = os.path.split(rf)[-1][:-4].split("..")
             source = fn[-2]
             state = fn[-1]
-            print('loading restults for {}::{} from {}'.format(source, state, rf))
+            print('loading the restults for {}::{} from {}'.format(source, state, rf))
             startLine = 0
             for count, analysisGrid in enumerate(self.analysisGrids):
                 if count:

--- a/honeybee/radiance/recipe/daylightcoeff/gridbased.py
+++ b/honeybee/radiance/recipe/daylightcoeff/gridbased.py
@@ -271,15 +271,32 @@ class DaylightCoeffGridBased(GenericGridBased):
             fn = os.path.split(rf)[-1][:-4].split("..")
             source = fn[-2]
             state = fn[-1]
-            print('loading the restults for {}::{} from {}'.format(source, state, rf))
+
+            folder, name = os.path.split(rf)
+            df = os.path.join(folder, 'sun..%s' % name)
+
+            print('loading the results for {}::{} from\n{}'.format(source, state, rf))
+
             startLine = 0
             for count, analysisGrid in enumerate(self.analysisGrids):
                 if count:
                     startLine += len(self.analysisGrids[count - 1])
 
-                analysisGrid.setValuesFromFile(
-                    rf, self.skyMatrix.hoys, source, state, startLine=startLine,
-                    header=True, checkPointCount=False
-                )
+                if not os.path.exists(df):
+                    # total value only
+                    analysisGrid.setValuesFromFile(
+                        rf, self.skyMatrix.hoys, source, state, startLine=startLine,
+                        header=True, checkPointCount=False
+                    )
+                else:
+                    # total and direct values
+                    print(
+                        'loading the direct results for {}::{} '
+                        'from\n{}'.format(source, state, df))
+
+                    analysisGrid.setCoupledValuesFromFile(
+                        rf, df, self.skyMatrix.hoys, source, state,
+                        startLine=startLine, header=True, checkPointCount=False
+                    )
 
         return self.analysisGrids


### PR DESCRIPTION
1. Updated solar access results reader. Results can be used similar to other grid-based analysis to be visualized hourly or cumulative.

![output_ufj7xc](https://user-images.githubusercontent.com/2915573/28324735-132296ee-6baa-11e7-88cb-b8d4b4e9173a.gif)

2. Exposed access to direct radiation. Now one can easily switch between direct, total and sky values for any point in time.

## Direct
![direct](https://user-images.githubusercontent.com/2915573/28324945-a0a4b1b4-6baa-11e7-8013-5b6a2a6b0f9c.png)

## Sky + Diffuse

![sky](https://user-images.githubusercontent.com/2915573/28324954-a89ac8cc-6baa-11e7-88f4-6802973a9d82.png)

## Total
![total](https://user-images.githubusercontent.com/2915573/28324969-b25394a2-6baa-11e7-8760-2a48e849f44b.png)


Next step is to finish post processing components.
0. hourly results
1. multiple hours results
2. max min
3. cumulative results
4. annual metrics
5. sDA, ASE

