### PR TITLE
Use python's default parameters instead of explictly setting variables

### DIFF
--- a/honeybee/_hbanalysissurface.py
+++ b/honeybee/_hbanalysissurface.py
@@ -567,7 +567,6 @@ class HBAnalysisSurface(HBObject):
             flipped: Flip the surface geometry.
             blacked: If True materials will all be set to plastic 0 0 0 0 0.
         """
-        mode = 1 if mode is None else mode
         return RadFile((self,)).to_rad_string(mode, include_materials, flipped, blacked)
 
     def write_rad_file(self, file_path, mode=1, include_materials=False,
@@ -585,7 +584,6 @@ class HBAnalysisSurface(HBObject):
             flipped: Flip the surface geometry.
             blacked: If True materials will all be set to plastic 0 0 0 0 0.
         """
-        mode = 1 if mode is None else mode
         assert os.path.isdir(os.path.split(file_path)[0]), \
             "Cannot find %s." % os.path.split(file_path)[0]
 

--- a/honeybee/hbfensurface.py
+++ b/honeybee/hbfensurface.py
@@ -48,14 +48,12 @@ class HBFenSurface(HBAnalysisSurface):
         hbsrf.write_rad_file(r"c:/ladybug/triangle.rad", include_materials=True)
     """
 
-    def __init__(self, name, sorted_points=None, is_name_set_by_user=False,
-                 rad_properties=None, ep_properties=None, states=None):
+    def __init__(self, name, sorted_points=[], is_name_set_by_user=False,
+                 rad_properties=None, ep_properties=None, states=()):
         """Init honeybee surface."""
         _surface_type = 5
         _is_type_set_by_user = True
-        sorted_points = sorted_points or []
 
-        states = states or ()
         HBAnalysisSurface.__init__(self, name, sorted_points, _surface_type,
                                    is_name_set_by_user, _is_type_set_by_user)
 

--- a/honeybee/hbshadesurface.py
+++ b/honeybee/hbshadesurface.py
@@ -22,12 +22,11 @@ class HBShadingSurface(HBAnalysisSurface):
 
     # TODO: Separate Zone:Detailed:Sahding
     def __init__(self, name, sorted_points=[], is_name_set_by_user=False,
-                 rad_properties=None, ep_properties=None, states=None):
+                 rad_properties=None, ep_properties=None, states=()):
         """Init honeybee surface."""
         _surface_type = 6
         _is_type_set_by_user = True
 
-        states = states or ()
         HBAnalysisSurface.__init__(self, name, sorted_points, _surface_type,
                                    is_name_set_by_user, _is_type_set_by_user)
 

--- a/honeybee/hbzone.py
+++ b/honeybee/hbzone.py
@@ -187,7 +187,6 @@ class HBZone(HBObject):
             flipped: Flip the surface geometry.
             blacked: If True materials will all be set to plastic 0 0 0 0 0.
         """
-        mode = 1 if mode is None else mode
         return self.to_rad_file().to_rad_string(mode, include_materials, flipped,
                                                 blacked)
 
@@ -207,7 +206,6 @@ class HBZone(HBObject):
             flipped: Flip the surface geometry.
             blacked: If True materials will all be set to plastic 0 0 0 0 0.
         """
-        mode = 1 if mode is None else mode
         folder, filename = os.path.split(file_path)
         return self.to_rad_file().write(folder, filename, mode, include_materials,
                                         flipped, blacked, mkdir=True)

--- a/honeybee/radiance/command/rfluxmtx.py
+++ b/honeybee/radiance/command/rfluxmtx.py
@@ -178,9 +178,9 @@ class Rfluxmtx(RadianceCommand):
         return self._output_filename_format
 
     @output_filename_format.setter
-    def output_filename_format(self, value):
+    def output_filename_format(self, value=None):
         # TODO: Add testing logic for this !
-        self._output_filename_format = value or None
+        self._output_filename_format = value
 
     @property
     def view_info_file(self):

--- a/honeybee/radiance/geometry/cone.py
+++ b/honeybee/radiance/geometry/cone.py
@@ -27,8 +27,8 @@ class Cone(RadianceGeometry):
     center_pt_end = RadianceTuple('center_pt_end', tuple_size=3, num_type=float)
     radius_end = RadianceNumber('radius_end', check_positive=True)
 
-    def __init__(self, name, center_pt_start=None, radius_start=None,
-                 center_pt_end=None, radius_end=None, modifier=None):
+    def __init__(self, name, center_pt_start=(0, 0, 0), radius_start=10,
+                 center_pt_end=(0, 0, 10), radius_end=0, modifier=None):
         """Radiance Cone.
 
         Attributes:
@@ -41,10 +41,10 @@ class Cone(RadianceGeometry):
             modifier: Geometry modifier (Default: "void").
         """
         RadianceGeometry.__init__(self, name, modifier=modifier)
-        self.center_pt_start = center_pt_start or (0, 0, 0)
-        self.radius_start = radius_start or 10
-        self.center_pt_end = center_pt_end or (0, 0, 10)
-        self.radius_end = radius_end or 0
+        self.center_pt_start = center_pt_start
+        self.radius_start = radius_start
+        self.center_pt_end = center_pt_end
+        self.radius_end = radius_end
 
         self._update_values()
 

--- a/honeybee/radiance/geometry/cylinder.py
+++ b/honeybee/radiance/geometry/cylinder.py
@@ -23,7 +23,7 @@ class Cylinder(RadianceGeometry):
     center_pt_end = RadianceTuple('center_pt_end', tuple_size=3, num_type=float)
     radius = RadianceNumber('radius', check_positive=True)
 
-    def __init__(self, name, center_pt_start=None, center_pt_end=None, radius=None,
+    def __init__(self, name, center_pt_start=(0, 0, 0), center_pt_end=(0, 0, 10), radius=10,
                  modifier=None):
         """Radiance Cylinder.
 
@@ -37,9 +37,9 @@ class Cylinder(RadianceGeometry):
             modifier: Geometry modifier (Default: "void").
         """
         RadianceGeometry.__init__(self, name, modifier=modifier)
-        self.center_pt_start = center_pt_start or (0, 0, 0)
-        self.center_pt_end = center_pt_end or (0, 0, 10)
-        self.radius = radius or 10
+        self.center_pt_start = center_pt_start
+        self.center_pt_end = center_pt_end
+        self.radius = radius
 
         self._update_values()
 

--- a/honeybee/radiance/geometry/ring.py
+++ b/honeybee/radiance/geometry/ring.py
@@ -27,8 +27,8 @@ class Ring(RadianceGeometry):
     radius_inner = RadianceNumber('radius_inner', check_positive=True)
     radius_outer = RadianceNumber('radius_outer', check_positive=True)
 
-    def __init__(self, name, center_pt=None, radius_inner=None,
-                 surface_normal=None, radius_outer=None, modifier=None):
+    def __init__(self, name, center_pt=(0, 0, 0), radius_inner=10,
+                 surface_normal=(0, 0, 10), radius_outer=0, modifier=None):
         """Radiance Ring.
 
         Attributes:
@@ -41,10 +41,10 @@ class Ring(RadianceGeometry):
             modifier: Geometry modifier (Default: "void").
         """
         RadianceGeometry.__init__(self, name, modifier=modifier)
-        self.center_pt = center_pt or (0, 0, 0)
-        self.radius_inner = radius_inner or 10
-        self.surface_normal = surface_normal or (0, 0, 10)
-        self.radius_outer = radius_outer or 0
+        self.center_pt = center_pt
+        self.radius_inner = radius_inner
+        self.surface_normal = surface_normal
+        self.radius_outer = radius_outer
 
         self._update_values()
 

--- a/honeybee/radiance/geometry/source.py
+++ b/honeybee/radiance/geometry/source.py
@@ -21,7 +21,7 @@ class Source(RadianceGeometry):
     direction = RadianceTuple('direction', tuple_size=3, num_type=float)
     angle = RadianceNumber('angle', num_type=float, check_positive=True)
 
-    def __init__(self, name, direction=None, angle=None, modifier=None):
+    def __init__(self, name, direction=(0, 0, -1), angle=0.533, modifier=None):
         """Radiance Source.
 
         Attributes:
@@ -36,8 +36,8 @@ class Source(RadianceGeometry):
             print(source)
         """
         RadianceGeometry.__init__(self, name, modifier=modifier)
-        self.direction = direction or (0, 0, -1)
-        self.angle = angle or 0.533
+        self.direction = direction
+        self.angle = angle
 
         self._update_values()
 

--- a/honeybee/radiance/geometry/sphere.py
+++ b/honeybee/radiance/geometry/sphere.py
@@ -17,7 +17,7 @@ class Sphere(RadianceGeometry):
     center_pt = RadianceTuple('center_pt', tuple_size=3, num_type=float)
     radius = RadianceNumber('radius', check_positive=True)
 
-    def __init__(self, name, center_pt=None, radius=None, modifier=None):
+    def __init__(self, name, center_pt=(0, 0, 0), radius=1, modifier=None):
         """Radiance Sphere.
 
         Attributes:
@@ -32,8 +32,8 @@ class Sphere(RadianceGeometry):
             print(sphere)
         """
         RadianceGeometry.__init__(self, name, modifier=modifier)
-        self.center_pt = center_pt or (0, 0, 0)
-        self.radius = radius or 1
+        self.center_pt = center_pt
+        self.radius = radius
 
         self._update_values()
 

--- a/honeybee/radiance/material/bsdf.py
+++ b/honeybee/radiance/material/bsdf.py
@@ -28,7 +28,7 @@ class BSDF(RadianceMaterial):
 
     # TODO(): compress file content: https://stackoverflow.com/a/15529390/4394669
     # TODO(): restructure the code to include xml data and not the file.
-    def __init__(self, xmlfile, name=None, up_orientation=None, thickness=None,
+    def __init__(self, xmlfile, name=None, up_orientation=(0.01, 0.01, 1.00), thickness=0,
                  modifier="void"):
         """Create BSDF material."""
         assert os.path.isfile(xmlfile), 'Invalid path: {}'.format(xmlfile)
@@ -41,7 +41,7 @@ class BSDF(RadianceMaterial):
         RadianceMaterial.__init__(self, name, modifier=modifier)
 
         try:
-            x, y, z = up_orientation or (0.01, 0.01, 1.00)
+            x, y, z = up_orientation
         except TypeError as e:
             try:
                 # Dynamo!
@@ -52,7 +52,7 @@ class BSDF(RadianceMaterial):
 
         self.up_orientation = float(x), float(y), float(z)
 
-        self.thickness = thickness or 0
+        self.thickness = thickness
 
         max_ln_count = 2000
         with open(self.xmlfile, 'rb') as inf:

--- a/honeybee/radiance/parameters/rpict.py
+++ b/honeybee/radiance/parameters/rpict.py
@@ -457,10 +457,7 @@ class RpictParameters(AdvancedRadianceParameters):
         return self._quality
 
     @quality.setter
-    def quality(self, value):
-
-        value = value or 0
-
+    def quality(self, value= 0):
         assert (0 <= int(value) <= 2), \
             "Quality can only be 0:low, 1: medium or 2: high quality"
 

--- a/honeybee/radiance/parameters/rtrace.py
+++ b/honeybee/radiance/parameters/rtrace.py
@@ -40,7 +40,7 @@ class RtraceParameters(AdvancedRadianceParameters):
           -ar 128 -lr 8 -dt 0.15 -dr 3 -ds 0.05 -dp 512 -u
     """
 
-    def __init__(self, quality=None):
+    def __init__(self, quality=0):
         """Create Radiance paramters."""
         AdvancedRadianceParameters.__init__(self)
 
@@ -344,9 +344,9 @@ class RtraceParameters(AdvancedRadianceParameters):
         return self._quality
 
     @quality.setter
-    def quality(self, value):
+    def quality(self, value=0):
 
-        value = int(value) or 0
+        value = int(value)
 
         assert 0 <= value <= 2, \
             "Quality can only be 0:low, 1: medium or 2: high quality"

--- a/honeybee/radiance/radfile.py
+++ b/honeybee/radiance/radfile.py
@@ -46,7 +46,6 @@ class RadFile(object):
 
     def find_bsdf_materials(self, mode=1):
         """Return a list fo BSDF materials if any."""
-        mode = 1 if mode is None else mode
         if mode == 0:
             # do not include children surface
             mt = set(srf.radiance_material for srf in self.hb_surfaces
@@ -81,7 +80,6 @@ class RadFile(object):
                 1 - Include children surfaces.
                 2 - Only children surfaces.
         """
-        mode = 1 if mode is None else mode
         if mode == 0:
             # do not include children surface
             mt = set(srf.radiance_material.name for srf in self.hb_surfaces)
@@ -151,7 +149,6 @@ class RadFile(object):
         assert not (blacked and glowed), \
             ValueError('You can either use blacked or glowed option.')
 
-        mode = 1 if mode is None else mode
         if mode == 0:
             # do not include children surface
             if blacked:
@@ -223,7 +220,6 @@ class RadFile(object):
             join: Set to True to join the output strings (Default: False).
             flipped: Flip the surface geometry.
         """
-        mode = 1 if mode is None else mode
         get_polygon = self.get_surface_rad_string
         if mode == 0:
             # do not include children surface
@@ -256,7 +252,6 @@ class RadFile(object):
             flipped: Flip the surface geometry.
             blacked: If True materials will all be set to plastic 0 0 0 0 0.
         """
-        mode = 1 if mode is None else mode
         if include_materials:
             return '\n'.join((self.materials(mode, True, blacked, glowed),
                               self.geometries(mode, True, flipped))) + '\n'

--- a/honeybee/radiance/recipe/_gridbasedbase.py
+++ b/honeybee/radiance/recipe/_gridbasedbase.py
@@ -98,7 +98,7 @@ class GenericGridBased(AnalysisRecipe):
         return LegendParameters([0, 3000])
 
     @staticmethod
-    def analysis_grids_from_points_and_vectors(point_groups, vector_groups=None):
+    def analysis_grids_from_points_and_vectors(point_groups, vector_groups=((),)):
         """Create analysisGrid classes from points and vectors.
 
         Args:
@@ -111,7 +111,7 @@ class GenericGridBased(AnalysisRecipe):
                 direction of corresponding point in testPts. If the vector is not
                 provided (0, 0, 1) will be assigned.
         """
-        vector_groups = vector_groups or ((),)
+        vector_groups = vector_groups
 
         vector_groups = tuple(vector_groups[i] if i < len(vector_groups)
                               else vector_groups[-1] for i in range(len(point_groups)))

--- a/honeybee/radiance/recipe/_recipebase.py
+++ b/honeybee/radiance/recipe/_recipebase.py
@@ -194,8 +194,6 @@ class AnalysisRecipe(object):
         iscreated = preparedir(target_folder, False)
         assert iscreated, "Failed to create %s. Try a different path!" % target_folder
 
-        project_name = project_name or 'untitled'
-
         _basePath = os.path.join(target_folder, project_name, self.sub_folder)
         iscreated = preparedir(_basePath, remove_content=False)
         assert iscreated, "Failed to create %s. Try a different path!" % _basePath

--- a/honeybee/radiance/recipe/directreflection/gridbased.py
+++ b/honeybee/radiance/recipe/directreflection/gridbased.py
@@ -23,7 +23,7 @@ class DirectReflectionGridBased(SolarAccessGridBased):
     """
 
     def __init__(self, sun_vectors, hoys, analysis_grids, timestep=1,
-                 reflective_surfaces=None, context_surfaces=None,
+                 reflective_surfaces=[], context_surfaces=[],
                  sub_folder='directreflection'):
         """
         Args:
@@ -40,9 +40,6 @@ class DirectReflectionGridBased(SolarAccessGridBased):
             sub_folder: Analysis subfolder for this recipe. (Default: "directreflection")
         """
         # update materials for reflective objects and context
-        reflective_surfaces = reflective_surfaces or []
-        context_surfaces = context_surfaces or []
-
         hb_objects = self.update_reflective_surfaces(reflective_surfaces) + \
             context_surfaces
 
@@ -85,7 +82,7 @@ class DirectReflectionGridBased(SolarAccessGridBased):
 
     @classmethod
     def from_suns(cls, suns, point_groups, vector_groups=[], timestep=1,
-                  reflective_surfaces=None, context_surfaces=None,
+                  reflective_surfaces=[], context_surfaces=[],
                   sub_folder='directreflection'):
         """Create direct reflection recipe from LB sun objects.
 
@@ -107,9 +104,6 @@ class DirectReflectionGridBased(SolarAccessGridBased):
             sub_folder: Analysis subfolder for this recipe. (Default: "directreflection")
         """
         # update materials for reflective objects and context
-        reflective_surfaces = reflective_surfaces or []
-        context_surfaces = context_surfaces or []
-
         hb_objects = cls.update_reflective_surfaces(reflective_surfaces) + \
             context_surfaces
 
@@ -118,13 +112,10 @@ class DirectReflectionGridBased(SolarAccessGridBased):
 
     @classmethod
     def from_location_and_hoys(cls, location, hoys, point_groups, vector_groups=[],
-                               timestep=1, reflective_surfaces=None,
-                               context_surfaces=None, sub_folder='directreflection'):
+                               timestep=1, reflective_surfaces=[],
+                               context_surfaces=[], sub_folder='directreflection'):
         """Create direct reflection recipe from Location and hours of year."""
         # update materials for reflective objects and context
-        reflective_surfaces = reflective_surfaces or []
-        context_surfaces = context_surfaces or []
-
         hb_objects = cls.update_reflective_surfaces(reflective_surfaces) + \
             context_surfaces
 
@@ -135,12 +126,12 @@ class DirectReflectionGridBased(SolarAccessGridBased):
     @classmethod
     def from_location_and_analysis_period(
         cls, location, analysis_period, point_groups, vector_groups=None,
-            reflective_surfaces=None, context_surfaces=None,
+            reflective_surfaces=[], context_surfaces=[],
             sub_folder='directreflection'):
         """Create direct reflection recipe from Location and analysis period."""
         # update materials for reflective objects and context
-        reflective_surfaces = reflective_surfaces or []
-        context_surfaces = context_surfaces or []
+        reflective_surfaces = reflective_surfaces
+        context_surfaces = context_surfaces
 
         hb_objects = cls.update_reflective_surfaces(reflective_surfaces) + \
             context_surfaces

--- a/honeybee/radiance/recipe/recipedcutil.py
+++ b/honeybee/radiance/recipe/recipedcutil.py
@@ -682,8 +682,8 @@ def image_based_view_coeff_matrix_commands(
     return rflux
 
 
-def coeff_matrix_commands(output_name, receiver, rad_files, sender, points_file=None,
-                          number_of_points=None, rfluxmtx_parameters=None):
+def coeff_matrix_commands(output_name, receiver, rad_files=(), sender='-', points_file=None,
+                          number_of_points=0, rfluxmtx_parameters=None):
     """Returns radiance commands to create coefficient matrix.
 
     Args:
@@ -698,9 +698,6 @@ def coeff_matrix_commands(output_name, receiver, rad_files, sender, points_file=
         rfluxmtx_parameters: Radiance parameters for Rfluxmtx command using a
             RfluxmtxParameters instance (Default: None).
     """
-    sender = sender or '-'
-    rad_files = rad_files or ()
-    number_of_points = number_of_points or 0
     rfluxmtx = Rfluxmtx()
 
     if sender == '-':

--- a/honeybee/radiance/recipe/solaraccess/gridbased.py
+++ b/honeybee/radiance/recipe/solaraccess/gridbased.py
@@ -177,11 +177,9 @@ class SolarAccessGridBased(GenericGridBased):
 
     @classmethod
     def from_location_and_analysis_period(
-        cls, location, analysis_period, point_groups, vector_groups=None,
+        cls, location, analysis_period, point_groups, vector_groups=(),
             hb_objects=None, sub_folder='sunlighthour'):
         """Create sunlighthours recipe from Location and analysis period."""
-        vector_groups = vector_groups or ()
-
         sp = Sunpath.from_location(location)
 
         suns = tuple(sp.calculate_sun_from_hoy(hoy) for hoy in analysis_period.hoys)

--- a/honeybee/radiance/resultcollection/imagecollection.py
+++ b/honeybee/radiance/resultcollection/imagecollection.py
@@ -23,7 +23,7 @@ class ImageCollection(object):
     combinations using pcomb.
     """
 
-    def __init__(self, name='untitled', output_folder=None):
+    def __init__(self, name='untitled', output_folder='.'):
         """Initiate an image collection."""
         # name of sources and their state. It's only meaningful in multi-phase daylight
         # analysis. In analysis for a single time it will be {None: [None]}
@@ -36,8 +36,8 @@ class ImageCollection(object):
         # in each dictionary the key is the hoy and the values are a list which
         # is [total, direct]. If the value is not available it will be None
         self._values = []
-        self.name = name or 'untitled'
-        self.output_folder = output_folder or '.'
+        self.name = name
+        self.output_folder = output_folder
 
     @property
     def sources(self):
@@ -206,13 +206,11 @@ class ImageCollection(object):
 
         sid, stateid = self._create_data_structure(source, state)
 
-        ind = index or 0
-
         for hoy, value in izip(hoys, file_paths):
             if hoy is None:
                 continue
             try:
-                self._values[sid][stateid][int(hoy * 60)][ind] = value
+                self._values[sid][stateid][int(hoy * 60)][index] = value
             except Exception as e:
                 raise ValueError(
                     'Failed to load {} results for window_group [{}], state[{}]'
@@ -452,7 +450,7 @@ class ImageCollection(object):
         return res.execute()
 
     def generate_combined_images_by_id(self, hoys=None, blinds_state_ids=None, mode=0,
-                                       outputs=None):
+                                       outputs=[]):
         """Get combined value from all sources based on state_id.
 
         Args:
@@ -475,7 +473,6 @@ class ImageCollection(object):
             'There should be a list of states for each hour. #states[{}] != #hours[{}]' \
             .format(len(blinds_state_ids), len(hoys))
 
-        outputs = outputs or []
         results = []
         for count, hoy in enumerate(hoys):
             image_col = []

--- a/honeybee/radiance/scene.py
+++ b/honeybee/radiance/scene.py
@@ -82,8 +82,7 @@ class Scene(object):
         return self._opaque_surfaces
 
     @opaque_surfaces.setter
-    def opaque_surfaces(self, opaque_surfaces):
-        opaque_surfaces = opaque_surfaces or ()
+    def opaque_surfaces(self, opaque_surfaces=()):
         self._opaque_surfaces = []
 
         for srf in opaque_surfaces:
@@ -104,8 +103,7 @@ class Scene(object):
         return self._non_opaque_surfaces
 
     @non_opaque_surfaces.setter
-    def non_opaque_surfaces(self, non_opaque_surfaces):
-        non_opaque_surfaces = non_opaque_surfaces or ()
+    def non_opaque_surfaces(self, non_opaque_surfaces=()):
         self._non_opaque_surfaces = []
         for srf in non_opaque_surfaces:
             assert srf.isHBSurface, \
@@ -125,8 +123,7 @@ class Scene(object):
         return self._dynamic_surfaces
 
     @dynamic_surfaces.setter
-    def dynamic_surfaces(self, dynamic_surfaces):
-        dynamic_surfaces = dynamic_surfaces or ()
+    def dynamic_surfaces(self, dynamic_surfaces=()):
         for srf in dynamic_surfaces:
             assert srf.isHBDynamicSurface, \
                 '{} is not a valid honeybee dynamic surface.'.format(srf.name)

--- a/honeybee/radiance/sky/_pointintimesky.py
+++ b/honeybee/radiance/sky/_pointintimesky.py
@@ -38,7 +38,7 @@ class PointInTimeSky(RadianceSky):
         '4\n' \
         '0 0 -1 180\n'
 
-    def __init__(self, location=None, month=9, day=21, hour=12, north=0, suffix=None):
+    def __init__(self, location=None, month=9, day=21, hour=12, north=0, suffix=''):
         """Create sky."""
         RadianceSky.__init__(self)
 
@@ -47,7 +47,7 @@ class PointInTimeSky(RadianceSky):
             '{} is not a Ladybug Location.'.format(self.location)
         self._datetime = DateTime(month, day, hour)
         self.north = float(north % 360)
-        self.suffix = suffix or ''
+        self.suffix = suffix
 
     @classmethod
     def from_lat_long(cls, city, latitude, longitude, timezone, elevation,
@@ -120,9 +120,8 @@ class PointInTimeSky(RadianceSky):
             '_{}'.format(self.suffix) if self.suffix else ''
         )
 
-    def write_sky_ground(self, folder, filename=None):
+    def write_sky_ground(self, folder, filename='groundSky.rad'):
         """Write sky and ground materials to a file."""
-        filename = filename or 'groundSky.rad'
         if not filename.lower().endswith('.rad'):
             filename += '.rad'
         return write_to_file_by_name(folder, filename, self.SKYGROUNDMATERIAL, True)

--- a/honeybee/radiance/sky/analemma.py
+++ b/honeybee/radiance/sky/analemma.py
@@ -29,14 +29,13 @@ class Analemma(RadianceSky):
             sun_up_hours: List of hours of the year that corresponds to sun_vectors.
         """
         RadianceSky.__init__(self)
-        vectors = sun_vectors or []
         # reverse sun vectors
-        self._sun_vectors = tuple(tuple(v) for v in vectors)
+        self._sun_vectors = tuple(tuple(v) for v in sun_vectors)
         self._sun_up_hours = sun_up_hours
-        assert len(sun_up_hours) == len(vectors), \
+        assert len(sun_up_hours) == len(sun_vectors), \
             ValueError(
                 'Length of vectors [%d] does not match the length of hours [%d]' %
-                (len(vectors), len(sun_up_hours))
+                (len(sun_vectors), len(sun_up_hours))
         )
 
     @classmethod
@@ -45,7 +44,7 @@ class Analemma(RadianceSky):
         return cls(inp['sun_vectors'], inp['sun_up_hours'])
 
     @classmethod
-    def from_location(cls, location, hoys=None, north=0, is_leap_year=False):
+    def from_location(cls, location, hoys=range(8760), north=0, is_leap_year=False):
         """Generate a radiance-based analemma for a location.
 
         Args:
@@ -57,8 +56,6 @@ class Analemma(RadianceSky):
         """
         sun_vectors = []
         sun_up_hours = []
-        hoys = hoys or range(8760)
-        north = north or 0
 
         sp = Sunpath.from_location(location, north)
         sp.is_leap_year = is_leap_year

--- a/honeybee/radiance/sky/certainIlluminance.py
+++ b/honeybee/radiance/sky/certainIlluminance.py
@@ -26,9 +26,8 @@ class CertainIlluminanceLevel(CIE):
             sky_type: An integer between 0..1 to indicate CIE Sky Type.
                 [0] cloudy sky, [1] uniform sky (default: 0)
         """
-        sky_type = sky_type or 0
         CIE.__init__(self, sky_type=sky_type + 4, suffix=suffix)
-        self.illuminance_value = illuminance_value or 10000
+        self.illuminance_value = illuminance_value
 
     @classmethod
     def from_json(cls, rec_json):

--- a/honeybee/radiance/sky/skymatrix.py
+++ b/honeybee/radiance/sky/skymatrix.py
@@ -24,7 +24,7 @@ class SkyMatrix(RadianceSky):
     __slots__ = ('_wea', 'hoys', '_sky_type', '_sky_matrixParameters',
                  '_mode', 'suffix', 'north')
 
-    def __init__(self, wea, sky_density=1, north=0, hoys=None, mode=0, suffix=None):
+    def __init__(self, wea, sky_density=1, north=0, hoys=None, mode=0, suffix=''):
         """Create sky."""
         RadianceSky.__init__(self)
         self.wea = wea
@@ -34,13 +34,12 @@ class SkyMatrix(RadianceSky):
             # this is a design issue in Honeybe and should be fixed by removing defulting
             # values to range(8760)
             self.hoys = [hour - 0.5 for hour in wea.hoys]
-        sky_density = sky_density or 1
         self._sky_type = 0  # default to visible radiation
         self._sky_matrixParameters = GendaymtxParameters(output_type=self._sky_type)
         self.north = north
         self.sky_density = sky_density
         self.mode = mode
-        self.suffix = suffix or ''
+        self.suffix = suffix
 
     @classmethod
     def from_json(cls, rec_json):

--- a/honeybee/schedule.py
+++ b/honeybee/schedule.py
@@ -18,9 +18,8 @@ class Schedule(object):
 
     __slots__ = ('_values', '_hoys', '_occupied_hours')
 
-    def __init__(self, values, hoys=None):
+    def __init__(self, values, hoys=xrange(8760)):
         """Init Schedule."""
-        hoys = hoys or xrange(8760)
         self._values = tuple(values)
         # put the hours in a set for quick look up
         self._hoys = tuple(hoys)
@@ -34,8 +33,8 @@ class Schedule(object):
             .format(len(self._values), len(self._hoys))
 
     @classmethod
-    def from_workday_hours(cls, occ_hours=None, off_hours=None, weekend=None,
-                           default_value=None):
+    def from_workday_hours(cls, occ_hours=(8, 17), off_hours=(12, 13), weekend=(6,7),
+                           default_value=1):
         """Create a schedule from Ladybug's AnalysisPeriod.
 
         Args:
@@ -48,10 +47,7 @@ class Schedule(object):
             default_value: Default value for occupancy hours (Default: 1).
         """
         daily_hours = [0] * 24
-        occ_hours = occ_hours or (8, 17)
-        off_hours = off_hours or (12, 13)
-        weekend = [0] if weekend == [0] else set(weekend) if weekend else set((6, 7))
-        default_value = default_value or 1
+        weekend = [0] if weekend == [0] else set(weekend)
 
         # create daily schedules
         for h in xrange(*occ_hours):
@@ -77,8 +73,8 @@ class Schedule(object):
         return cls(values, hours)
 
     @classmethod
-    def from_analysis_period(cls, occ_period=None, off_hours=None, weekend=None,
-                             default_value=None):
+    def from_analysis_period(cls, occ_period=None, off_hours=(12,13), weekend=(6,7),
+                             default_value=1):
         """Create a schedule from Ladybug's AnalysisPeriod.
 
         Args:
@@ -91,9 +87,9 @@ class Schedule(object):
             default_value: Default value for occupancy hours (Default: 1).
         """
         occ_period = occ_period or AnalysisPeriod(stHour=8, endHour=17)
-        off_hours = set(off_hours) if off_hours else set((12, 13))
-        weekend = [0] if weekend == [0] else set(weekend) if weekend else set((6, 7))
-        default_value = default_value or 1
+        off_hours = set(off_hours)
+        weekend = [0] if weekend == [0] else set(weekend)
+        default_value = default_value
 
         try:
             hours = tuple(h for h in occ_period.hoys)

--- a/honeybee/surfaceproperties.py
+++ b/honeybee/surfaceproperties.py
@@ -211,7 +211,6 @@ class SurfaceState(object):
         """
         if not self.surfaces:
             return ''
-        mode = 1 if mode is None else mode
         return RadFile(self.surfaces).to_rad_string(mode, include_materials,
                                                     flipped, blacked)
 


### PR DESCRIPTION
There's no need to explicitly set variables to what they've been
declared as default function parameters. This can also be seen when
defaulting a parameter value to `None`, and subsequently setting the
value in the function body explicitly.  It's at best dead code which
needlessly requires the programmer to keep track of additional details
when making changes.

At worst, there may be unintended consequences if the code is written
carelessly. For example, in
```
    def __init__(self, illuminance_value=10000, sky_type=0, suffix=None):
        self.illuminance_value = illuminance_value or 10000
```
if we try to instantiate `foo(0)`, this instance would have an
illuminance value of 10000 instead of 0.

Both CPython and IronPython honor the default parameters, so there's no
reason to set them explicitly.