### PR TITLE
Fix instatiating `CertainIlluminanceLevel` with 0 lux

### DIFF
--- a/honeybee/radiance/sky/certainIlluminance.py
+++ b/honeybee/radiance/sky/certainIlluminance.py
@@ -28,7 +28,7 @@ class CertainIlluminanceLevel(CIE):
         """
         sky_type = sky_type or 0
         CIE.__init__(self, sky_type=sky_type + 4, suffix=suffix)
-        self.illuminance_value = illuminance_value or 10000
+        self.illuminance_value = 10000 if illuminance_value is None else illuminance_value
 
     @classmethod
     def from_json(cls, rec_json):


### PR DESCRIPTION
This should fix the issue of instantiating `CertainIlluminanceLevel` with a lux of 0.