### PR TITLE
fix(dependencies): use requirements.txt to set `install_requires` in …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+lbt-ladybug==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ import sys
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setuptools.setup(
     name="lbt-honeybee",
     use_scm_version = True,
@@ -17,9 +20,7 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/honeybee",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=[
-        'lbt-ladybug'
-    ],
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
…setup.py

This should force a specific version of lbt-ladybug as a dependency of honeybee.

#281 

Probably worth adding the same change to the [honeybee-core](https://github.com/ladybug-tools/honeybee-core) repo.