### PR TITLE
chore(project manager): add hacktoberfest config

### DIFF
--- a/.github/project-manager.yml
+++ b/.github/project-manager.yml
@@ -68,6 +68,18 @@ projects:
             - todo
             - in progress
 
+  - name: Hacktoberfest
+    type: org
+    issue_type: issue
+    label: hacktoberfest
+    columns: 
+      - name: honeybee
+        labels:
+          - hacktoberfest
+      - name: done
+        labels:
+          - done
+
 labels:
 - name: honeybee
   color: "#FFFB00"
@@ -84,3 +96,6 @@ labels:
   color: "#EDEDED"
 - name: done
   color: "#EDEDED"
+
+- name: hacktoberfest
+  color: "#802AC1"


### PR DESCRIPTION
This PR is copied across a bunch of repositories to set up a global kanban to manage triage, backlog and issue progress for multiple repositories as well as enable a Hacktoberfest board to help people navigate and find issue they might want to help with.