### PR TITLE
adding .DS_Store to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tox.ini
 /.cache
 /.vscode
 venv
+
+# for users on a Mac system
+.DS_Store


### PR DESCRIPTION
Users on a Mac System may encounter .DS_Store file (Desktop Service Store) every time one navigated to a folder.
These remain hidden on Mac, but is visible and annoying on the GitHub Repo.
adding .DS_Store to .gitignore eliminates that nuisance.