### PR TITLE
fix(pypi): Remove automatic deployment to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check [this repository](https://github.com/mostaphaRoudsari/honeybee) for the le
 ## Installation
 
 ```
-pip install lbt-honeybee
+pip install lbt-honeybee==0.1.16
 ```
 
 ## Tentative road map

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,5 +22,5 @@ else
   exit 1
 fi
 
-deploy_to_pypi
+# deploy_to_pypi
 build_docs $NEXT_RELEASE_VERSION

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setuptools.setup(
-    name="lbt-honeybee",
+    name="honeybee-plus",
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     author="Ladybug Tools",


### PR DESCRIPTION
We are now going to use the lbt-honeybee package as a shortcut for installing honeybee and all of its extensions.

I am leaving all of the CI files there in case we ever find we need to bring it back but I made sure that the package name would be `honeybee-plus` if we do so.